### PR TITLE
#20 MRTK script default again

### DIFF
--- a/HoloOSCv2/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs
+++ b/HoloOSCv2/Assets/MixedRealityToolkit.SDK/Features/Input/Handlers/TransformScaleHandler.cs
@@ -29,8 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("Minimum scaling allowed")]
         private  float scaleMinimum = 0.2f;
 
-        //private Vector3 minimumScale;       CHANGED FROM PRIVATE
-        public Vector3 minimumScale;
+        private Vector3 minimumScale;
         
         public float ScaleMinimum
         {
@@ -46,7 +45,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         [Tooltip("Maximum scaling allowed")]
         private float scaleMaximum = 2f;
 
-        public Vector3 maximumScale; //        CHANGED FROM PRIVATE
+        private Vector3 maximumScale; 
 
         public float ScaleMaximum
         {

--- a/HoloOSCv2/Assets/Prefabs/Source.prefab
+++ b/HoloOSCv2/Assets/Prefabs/Source.prefab
@@ -213,6 +213,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1327461097190608845}
+        m_MethodName: checkMat
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: Microsoft.MixedReality.Toolkit.UI.ManipulationEvent, Microsoft.MixedReality.Toolkit.SDK,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   OnHoverEntered:
@@ -287,10 +298,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   targetTransform: {fileID: 1327461097190608881}
-  scaleMinimum: 0.5
-  minimumScale: {x: 0.05, y: 0.05, z: 0.05}
-  scaleMaximum: 3
-  maximumScale: {x: 0.3, y: 0.3, z: 0.3}
+  scaleMinimum: 0
+  scaleMaximum: 0
   relativeToInitialState: 1
 --- !u!1 &3974435328859267028
 GameObject:


### PR DESCRIPTION
Scale-calculation is now fully on the SourceObject.cs. Changes to the TransformScaleHandler (MRTK) changed back to default.
Additionally the Source-Material changes to blue when muted (Method on Prefab(Source) added in "On Manipulation ended")